### PR TITLE
refactored test suite, using pytest fixtures to remove boilerplate

### DIFF
--- a/src/phyltr/commands/base.py
+++ b/src/phyltr/commands/base.py
@@ -76,7 +76,8 @@ class PhyltrCommand:
                 if res is not None:
                     yield res
             except StopIteration:
-                stream.close()
+                if hasattr(stream, 'close'):
+                    stream.close()
                 break
         for tree in self.postprocess():
             yield tree

--- a/tests/cat_tests.py
+++ b/tests/cat_tests.py
@@ -1,42 +1,29 @@
-import fileinput
-
-from phyltr.plumbing.sources import NewickParser, ComplexNewickParser
 from phyltr.commands.cat import Cat
 
-def test_basic_cat():
-    lines = fileinput.input("tests/treefiles/basic.trees")
-    trees = NewickParser().consume(lines)
-    trees = Cat().consume(trees)
-    assert sum((1 for t in trees)) == 6
 
-def test_beast_nexus_output_cat():
-    lines = fileinput.input("tests/treefiles/beast_output.nex")
-    trees = ComplexNewickParser().consume(lines)
-    trees = Cat().consume(trees)
+def test_basic_cat(basictrees):
+    trees = Cat().consume(basictrees)
+    assert sum((1 for _ in trees)) == 6
+
+def test_beast_nexus_output_cat(treefilenewick):
+    trees = Cat().consume(treefilenewick('beast_output.nex'))
     for t in trees:
         assert len(t.get_leaves()) == 26
 
-def test_beast_annotated_nexus_output_cat():
-    lines = fileinput.input("tests/treefiles/beast_output_rate_annotations.nex")
-    trees = ComplexNewickParser().consume(lines)
-    trees = Cat().consume(trees)
+def test_beast_annotated_nexus_output_cat(treefilenewick):
+    trees = Cat().consume(treefilenewick('beast_output_rate_annotations.nex'))
     for t in trees:
         for n in t.traverse():
             assert hasattr(n, "rate")
         assert len(t.get_leaves()) == 26
 
-def test_beast_vector_annotated_nexus_output_cat():
-    lines = fileinput.input("tests/treefiles/beast_output_geo_annotations.nex")
-    trees = ComplexNewickParser().consume(lines)
-    trees = Cat().consume(trees)
+def test_beast_vector_annotated_nexus_output_cat(treefilenewick):
+    trees = Cat().consume(treefilenewick('beast_output_geo_annotations.nex'))
     for t in trees:
         for n in t.traverse():
             assert hasattr(n, "location")
 
-def test_mr_bayes_nexus_output_cat():
-    lines = fileinput.input("tests/treefiles/mr_bayes_output.nex")
-    trees = ComplexNewickParser().consume(lines)
-    trees = Cat().consume(trees)
+def test_mr_bayes_nexus_output_cat(treefilenewick):
+    trees = Cat().consume(treefilenewick('mr_bayes_output.nex'))
     for t in trees:
         assert len(t.get_leaves()) == 12
-

--- a/tests/clades_tests.py
+++ b/tests/clades_tests.py
@@ -1,9 +1,6 @@
 from __future__ import division
 
-import fileinput
-
 from phyltr.main import build_pipeline
-from phyltr.plumbing.sources import NewickParser
 from phyltr.commands.clades import Clades
 
 def test_init_from_args():
@@ -17,13 +14,10 @@ def test_init_from_args():
     clades = Clades.init_from_args("-f 0.42")
     assert clades.frequency == 0.42
 
-def test_clades():
-    lines = fileinput.input("tests/treefiles/basic.trees")
-    trees = NewickParser().consume(lines)
+def test_clades(basictrees):
     clades = Clades(ages=True)
     # Spin through all trees
-    for t in clades.consume(trees):
-        pass
+    list(clades.consume(basictrees))
     # Check that the computed probabilities agree
     # with hand calculated equivalents
     assert clades.cp.clade_probs["A,B"] == 4.0 / 6.0
@@ -37,17 +31,13 @@ def test_clades():
     assert clades.cp.clade_probs["D,E,F"] == 5.0 / 6.0
     assert clades.cp.clade_probs["A,B,C,D,E,F"] == 6.0 / 6.0
 
-def test_degenerate_clades(tmpdir):
-    lines = fileinput.input("tests/treefiles/single_taxon.trees")
-    trees = NewickParser().consume(lines)
+def test_degenerate_clades(treefilenewick):
     clades = Clades(ages=True)
-    for t in clades.consume(trees):
-        pass
+    list(clades.consume(treefilenewick('single_taxon.trees')))
 
-def test_categorical_annotation():
+def test_categorical_annotation(treefilenewick):
     # This is just to make sure the clade probability calculator doesnt't
     # erroneously try to calculate means etc. of categorical annotations
-    lines = fileinput.input("tests/treefiles/basic.trees")
-    trees = NewickParser().consume(lines)
-    for t in build_pipeline("annotate -f tests/argfiles/categorical_annotation.csv -k taxon | clades", trees):
-        pass
+    list(build_pipeline(
+        "annotate -f tests/argfiles/categorical_annotation.csv -k taxon | clades",
+        treefilenewick('basic.trees')))

--- a/tests/collapse_tests.py
+++ b/tests/collapse_tests.py
@@ -1,15 +1,12 @@
-import fileinput
-
 import pytest
 
-from phyltr.plumbing.sources import NewickParser
 from phyltr.main import build_pipeline
 from phyltr.commands.annotate import Annotate
 from phyltr.commands.collapse import Collapse
 
-def test_init():
-    collapse = Collapse.init_from_args("--translate tests/argfiles/collapse.txt")
-    assert collapse.filename == "tests/argfiles/collapse.txt"
+def test_init(argfilepath):
+    collapse = Collapse.init_from_args("--translate {0}".format(argfilepath('collapse.txt')))
+    assert collapse.filename == argfilepath('collapse.txt')
 
     collapse = Collapse.init_from_args("--attribute collapsibility")
     assert collapse.attribute == "collapsibility"
@@ -18,26 +15,22 @@ def test_bad_init_no_args():
     with pytest.raises(ValueError):
         Collapse()
 
-def test_collapse():
-    lines = fileinput.input("tests/treefiles/basic.trees")
-    trees = list(NewickParser().consume(lines))
-    collapsed = Collapse({"left":("A","B","C"), "right":("D","E","F")}).consume(trees)
+def test_collapse(basictrees):
+    collapsed = Collapse(
+        {"left":("A","B","C"), "right":("D","E","F")}).consume(basictrees)
     # These groups are monophyletic in the first 5 of the 6 basic trees, so...
     for n, t in enumerate(collapsed):
         assert len(t.get_leaves()) == (2 if n < 5 else 6)
 
-def test_file_collapse():
-    lines = fileinput.input("tests/treefiles/basic.trees")
-    trees = list(NewickParser().consume(lines))
-    collapsed = Collapse(filename="tests/argfiles/collapse.txt").consume(trees)
+def test_file_collapse(basictrees, argfilepath):
+    collapsed = Collapse(filename=argfilepath("collapse.txt")).consume(basictrees)
     # These groups are monophyletic in the first 5 of the 6 basic trees, so...
     for n, t in enumerate(collapsed):
         assert len(t.get_leaves()) == (2 if n < 5 else 6)
 
-def test_attribute_collapse():
-    lines = fileinput.input("tests/treefiles/basic.trees")
-    trees = list(NewickParser().consume(lines))
-    annotated = Annotate("tests/argfiles/annotation.csv", "taxon").consume(trees)
+def test_attribute_collapse(basictrees):
+    annotated = Annotate(
+        "tests/argfiles/annotation.csv", "taxon").consume(basictrees)
     # f1 in the annotations applied above corresponds to the same left/right
     # split as the other tests above
     collapsed = Collapse(attribute="f1").consume(annotated)
@@ -45,23 +38,21 @@ def test_attribute_collapse():
     for n, t in enumerate(collapsed):
         assert len(t.get_leaves()) == (2 if n < 5 else 6)
 
-def test_attribute_singleton_collapse():
-    lines = fileinput.input("tests/treefiles/basic.trees")
-    trees = list(NewickParser().consume(lines))
-    collapsed = build_pipeline("annotate -f tests/argfiles/annotation.csv -k taxon | collapse --attribute f3", trees)
+def test_attribute_singleton_collapse(treefilenewick, argfilepath):
+    collapsed = build_pipeline(
+        "annotate -f {0} -k taxon | collapse --attribute f3".format(argfilepath('annotation.csv')),
+        treefilenewick('basic.trees'))
     for t in collapsed:
         assert len(t.get_leaves()) == 6
 
-def test_non_collapse():
-    lines = fileinput.input("tests/treefiles/basic.trees")
-    trees = list(NewickParser().consume(lines))
+def test_non_collapse(basictrees):
+    trees = list(basictrees)
     collapsed = Collapse({"non-existent":("X","Y","Z")}).consume(trees)
     for t1, t2 in zip(trees, collapsed):
         assert t1.write() == t2.write()
 
-def test_attribute_non_collapse():
-    lines = fileinput.input("tests/treefiles/basic.trees")
-    trees = list(NewickParser().consume(lines))
+def test_attribute_non_collapse(basictrees):
+    trees = list(basictrees)
     collapsed = Collapse(attribute="foo").consume(trees)
     for t1, t2 in zip(trees, collapsed):
         assert t1.write() == t2.write()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,49 @@
+import os
+import fileinput
+
+import pytest
+
+from phyltr.plumbing.sources import NewickParser, ComplexNewickParser
+
+
+@pytest.fixture(scope='session')
+def argfilepath():
+    def path(fname):
+        return os.path.join(os.path.dirname(__file__), 'argfiles', fname)
+    return path
+
+
+@pytest.fixture(scope='session')
+def emptyargs(argfilepath):
+    return argfilepath('empty.txt')
+
+
+@pytest.fixture(scope='session')
+def treefilepath():
+    def path(fname):
+        return os.path.join(os.path.dirname(__file__), 'treefiles', fname)
+    return path
+
+
+@pytest.fixture(scope='session')
+def treefile(treefilepath):
+    def lines(*fnames):
+        return fileinput.input([treefilepath(fname) for fname in fnames])
+    return lines
+
+
+@pytest.fixture
+def treefilenewick(treefile):
+    def newick(fname):
+        parser = NewickParser if fname.endswith('.trees') else ComplexNewickParser
+        lines = treefile(fname)
+        res = list(parser().consume(lines))
+        # Note: NewickParser and ComplexNewickParser do not close the stream upon consumption!
+        lines.close()
+        return res
+    return newick
+
+
+@pytest.fixture
+def basictrees(treefilenewick):
+    return treefilenewick('basic.trees')

--- a/tests/consensus_tests.py
+++ b/tests/consensus_tests.py
@@ -1,6 +1,3 @@
-import fileinput
-
-from phyltr.plumbing.sources import ComplexNewickParser, NewickParser
 from phyltr.commands.consensus import Consensus
 from phyltr.commands.length import Length
 
@@ -11,29 +8,22 @@ def test_init_from_args():
     consensus = Consensus.init_from_args("-f 0.42")
     assert consensus.frequency == 0.42
 
-def test_consensus():
-    lines = fileinput.input("tests/treefiles/basic.trees")
-    trees = NewickParser().consume(lines)
-    consensus = list(Consensus().consume(trees))
+def test_consensus(basictrees):
+    consensus = list(Consensus().consume(basictrees))
     assert len(consensus) == 1
 
-def test_low_freq_consensus():
-    lines = fileinput.input("tests/treefiles/beast_output.nex")
-    trees = ComplexNewickParser().consume(lines)
-    consensus = list(Consensus(frequency=0.25).consume(trees))
+def test_low_freq_consensus(treefilenewick):
+    consensus = list(Consensus(frequency=0.25).consume(treefilenewick('beast_output.nex')))
     assert len(consensus) == 1
 
-def test_annotation_consensus():
-    lines = fileinput.input("tests/treefiles/beast_output_rate_annotations.nex")
-    trees = ComplexNewickParser().consume(lines)
-    consensus = list(Consensus().consume(trees))[0]
+def test_annotation_consensus(treefilenewick):
+    consensus = list(Consensus().consume(treefilenewick('beast_output_rate_annotations.nex')))[0]
     for n in consensus.traverse():
         for attr in ("rate_mean", "rate_median", "rate_HPD"):
             assert hasattr(n, attr)
 
-def test_min_med_max_consensus():
-    lines = fileinput.input("tests/treefiles/basic.trees")
-    trees = list(NewickParser().consume(lines))
+def test_min_med_max_consensus(basictrees):
+    trees = list(basictrees)
 
     min_uniq = Consensus(lengths="min").consume(trees)
     min_lengths = Length().consume(min_uniq)

--- a/tests/dedupe_tests.py
+++ b/tests/dedupe_tests.py
@@ -1,11 +1,7 @@
-import fileinput
-
-from phyltr.plumbing.sources import NewickParser
 from phyltr.commands.dedupe import Dedupe
 
-def test_dedupe():
-    lines = fileinput.input("tests/treefiles/duplicate_taxa.trees")
-    trees = list(NewickParser().consume(lines))
+def test_dedupe(treefilenewick):
+    trees = list(treefilenewick('duplicate_taxa.trees'))
     for t in trees:
         orig_leaves = t.get_leaf_names()
         assert len(orig_leaves) == 6
@@ -17,9 +13,8 @@ def test_dedupe():
         assert len(leaves) == 5
         assert all((leaves.count(x) == 1  for x in ("A", "B", "C", "E", "F")))
 
-def test_monophyletic_dedupe():
-    lines = fileinput.input("tests/treefiles/monophyletic_dupe_taxa.trees")
-    trees = list(NewickParser().consume(lines))
+def test_monophyletic_dedupe(treefilenewick):
+    trees = list(treefilenewick('monophyletic_dupe_taxa.trees'))
     for t in trees:
         leaves = t.get_leaf_names()
         assert not all((leaves.count(x) == 1  for x in ("A", "B", "C", "E", "F")))

--- a/tests/grep_tests.py
+++ b/tests/grep_tests.py
@@ -1,11 +1,8 @@
-import fileinput
-
 import pytest
 
-from phyltr.plumbing.sources import NewickParser
 from phyltr.commands.grep import Grep
 
-def test_init_from_args():
+def test_init_from_args(argfilepath):
     grep = Grep.init_from_args("A,B,C")
     assert grep.taxa == set(("A","B","C"))
     assert grep.filename == None
@@ -14,31 +11,29 @@ def test_init_from_args():
     grep = Grep.init_from_args("A,B,C --inverse")
     assert grep.inverse == True
 
-    grep = Grep.init_from_args("--file tests/argfiles/taxa_abc.txt")
+    taxa_abc = argfilepath('taxa_abc.txt')
+    grep = Grep.init_from_args("--file {0}".format(taxa_abc))
     assert grep.taxa == set(("A","B","C"))
-    assert grep.filename == "tests/argfiles/taxa_abc.txt"
+    assert grep.filename == taxa_abc
 
 def test_bad_init_no_args():
     with pytest.raises(ValueError):
         Grep()
 
-def test_bad_init_empty_file():
+def test_bad_init_empty_file(emptyargs):
     with pytest.raises(ValueError):
-        Grep(filename="tests/argfiles/empty.txt")
+        Grep(filename=emptyargs)
 
-def test_trivial_grep():
+def test_trivial_grep(basictrees):
     """
     Test that grepping for all taxa in the tree just passes all trees.
     """
-
-    lines = fileinput.input("tests/treefiles/basic.trees")
-    trees = list(NewickParser().consume(lines))
+    trees = list(basictrees)
     grepped = list(Grep(["A","B","C","D","E","F"]).consume(trees))
     assert trees == grepped
 
-def test_grep():
-    lines = fileinput.input("tests/treefiles/basic.trees")
-    trees = list(NewickParser().consume(lines))
+def test_grep(basictrees):
+    trees = list(basictrees)
     grepper = Grep(["A","B"])
     grepped = grepper.consume(trees)
     # A and B are siblings in 4 of our standard testing trees
@@ -46,9 +41,8 @@ def test_grep():
     grepped = grepper.consume(trees)
     assert all("A:1,B:1" in t.write() for t in grepped)
 
-def test_inverse_grep():
-    lines = fileinput.input("tests/treefiles/basic.trees")
-    trees = list(NewickParser().consume(lines))
+def test_inverse_grep(basictrees):
+    trees = list(basictrees)
     grepper = Grep(["A","B"], inverse=True)
     grepped = grepper.consume(trees)
     # A and B are siblings in 4/6 of our standard testing trees

--- a/tests/height_tests.py
+++ b/tests/height_tests.py
@@ -1,12 +1,7 @@
-import fileinput
-
-from phyltr.plumbing.sources import NewickParser
 from phyltr.commands.height import Height
 
-def test_height():
-    lines = fileinput.input("tests/treefiles/basic.trees")
-    trees = NewickParser().consume(lines)
-    heights = Height().consume(trees)
+def test_height(basictrees):
+    heights = Height().consume(basictrees)
     for h in heights:
         assert type(h) == float
         assert h >= 0.0

--- a/tests/length_tests.py
+++ b/tests/length_tests.py
@@ -1,12 +1,7 @@
-import fileinput
-
-from phyltr.plumbing.sources import NewickParser
 from phyltr.commands.length import Length
 
-def test_length():
-    lines = fileinput.input("tests/treefiles/basic.trees")
-    trees = NewickParser().consume(lines)
-    lengths = Length().consume(trees)
+def test_length(basictrees):
+    lengths = Length().consume(basictrees)
     for l in lengths:
         assert type(l) == float
         assert l >= 0.0

--- a/tests/plot_tests.py
+++ b/tests/plot_tests.py
@@ -1,63 +1,32 @@
-import fileinput
-import tempfile
-import os
-
-import ete3
+import pytest
 
 from phyltr.main import build_pipeline
-from phyltr.plumbing.sources import NewickParser
-from phyltr.commands.plot import Plot, ultrametric
+from phyltr.commands.plot import Plot
 
-def dummy_wrapper_for_travis(f):
+
+@pytest.fixture
+def with_ete3():
     try:
         from ete3 import TreeStyle
-        dummy = False
+        return True
     except ImportError:
-        dummy = True
+        return False
 
-    def test_wrapped():
-        return f(dummy)
-    return test_wrapped
-
-@dummy_wrapper_for_travis
-def test_init_from_args(dummy=False):
-    if dummy:
+def test_init_from_args(with_ete3):
+    if not with_ete3:
         assert True
     else:
-        plot = Plot.init_from_args("")
+        Plot.init_from_args("")
 
-@dummy_wrapper_for_travis
-def test_plot(dummy=False):
+def test_plot(tmpdir, basictrees, with_ete3):
+    plot = Plot(dummy=not with_ete3, output=str(tmpdir.join('test')), height=600, width=800)
+    list(plot.consume(basictrees))
 
-    lines = fileinput.input("tests/treefiles/basic.trees")
-    trees = NewickParser().consume(lines)
-    with tempfile.NamedTemporaryFile() as fp:
-        plot = Plot(dummy=dummy, output=fp.name, height=600, width=800)
-        for x in plot.consume(trees):
-            pass
-    lines.close()
+def test_plot_multiple(tmpdir, basictrees, with_ete3):
+    plot = Plot(dummy=not with_ete3, output=str(tmpdir.join('test')), height=600, width=800, multiple=True)
+    list(plot.consume(basictrees))
 
-@dummy_wrapper_for_travis
-def test_plot_multiple(dummy=False):
-
-    lines = fileinput.input("tests/treefiles/basic.trees")
-    trees = NewickParser().consume(lines)
-    with tempfile.NamedTemporaryFile() as fp:
-        plot = Plot(dummy=dummy, output=fp.name, height=600, width=800, multiple=True)
-        for x in plot.consume(trees):
-            pass
-    lines.close()
-
-@dummy_wrapper_for_travis
-def test_plot_annotated(dummy=False):
-
-    lines = fileinput.input("tests/treefiles/basic.trees")
-    trees = NewickParser().consume(lines)
-    annotated_trees = build_pipeline("annotate --f tests/argfiles/annotation.csv -k taxon", source=trees)
-    with tempfile.NamedTemporaryFile() as fp:
-        plot = Plot(output=fp.name, attribute="f1", dummy=dummy)
-        for x in plot.consume(annotated_trees):
-            pass
-    lines.close()
-
-
+def test_plot_annotated(tmpdir, basictrees, with_ete3):
+    annotated_trees = build_pipeline("annotate --f tests/argfiles/annotation.csv -k taxon", source=basictrees)
+    plot = Plot(output=str(tmpdir.join('test')), attribute="f1", dummy=not with_ete3)
+    list(plot.consume(annotated_trees))

--- a/tests/pretty_tests.py
+++ b/tests/pretty_tests.py
@@ -1,6 +1,3 @@
-import fileinput
-
-from phyltr.plumbing.sources import NewickParser
 from phyltr.main import build_pipeline
 from phyltr.commands.pretty import Pretty
 
@@ -15,20 +12,14 @@ def test_init_from_args():
     pretty = Pretty.init_from_args("--label foo")
     assert pretty.label == "foo"
 
-def test_pretty():
-    lines = fileinput.input("tests/treefiles/basic.trees")
-    trees = NewickParser().consume(lines)
-    for x in Pretty().consume(trees):
+def test_pretty(basictrees):
+    for x in Pretty().consume(basictrees):
         assert type(x) == str
 
-def test_pretty_compressed_low_signal():
-    lines = fileinput.input("tests/treefiles/low_signal.trees")
-    trees = NewickParser().consume(lines)
-    for x in build_pipeline("support | pretty --compress", trees):
+def test_pretty_compressed_low_signal(treefilenewick):
+    for x in build_pipeline("support | pretty --compress", treefilenewick('low_signal.trees')):
         assert type(x) == str
 
-def test_pretty_compressed_mid_signal():
-    lines = fileinput.input("tests/treefiles/mid_signal.trees")
-    trees = NewickParser().consume(lines)
-    for x in build_pipeline("support | pretty --compress", trees):
+def test_pretty_compressed_mid_signal(treefilenewick):
+    for x in build_pipeline("support | pretty --compress", treefilenewick('mid_signal.trees')):
         assert type(x) == str

--- a/tests/rename_tests.py
+++ b/tests/rename_tests.py
@@ -1,51 +1,41 @@
-import fileinput
-
 import pytest
 
-from phyltr.plumbing.sources import NewickParser
 from phyltr.commands.rename import Rename
 
 
-def test_init():
-    rename = Rename.init_from_args("--file tests/argfiles/rename.txt")
+def test_init(argfilepath):
+    rename = Rename.init_from_args("--file {0}".format(argfilepath("rename.txt")))
     assert rename.remove == False
 
-    rename = Rename.init_from_args("--file tests/argfiles/rename.txt --remove-missing")
+    rename = Rename.init_from_args("--file {0} --remove-missing".format(argfilepath("rename.txt")))
     assert rename.remove == True
 
 def test_bad_init_no_args():
     with pytest.raises(ValueError):
         Rename()
 
-def test_rename():
-    lines = fileinput.input("tests/treefiles/basic.trees")
-    trees = NewickParser().consume(lines)
-    renamed = Rename({"A":"X"}).consume(trees)
+def test_rename(basictrees):
+    renamed = Rename({"A":"X"}).consume(basictrees)
     for t in renamed:
         leaves = t.get_leaf_names()
         assert "A" not in leaves
         assert "X" in leaves
         assert all((x in leaves for x in ("B", "C", "D", "E", "F")))
 
-def test_rename_from_file():
-    lines = fileinput.input("tests/treefiles/basic.trees")
-    trees = NewickParser().consume(lines)
-    renamed = Rename(filename="tests/argfiles/rename.txt").consume(trees)
+def test_rename_from_file(basictrees):
+    renamed = Rename(filename="tests/argfiles/rename.txt").consume(basictrees)
     for t in renamed:
         leaves = t.get_leaf_names()
         assert "A" not in leaves
         assert "X" in leaves
         assert all((x in leaves for x in ("B", "C", "D", "E", "F")))
 
-def test_rename_with_remove():
-    lines = fileinput.input("tests/treefiles/basic.trees")
-    trees = NewickParser().consume(lines)
+def test_rename_with_remove(basictrees):
     renamed = Rename({
         "A":"X",
         "B":"Y",
-        "C":"Z" }, remove=True).consume(trees)
+        "C":"Z" }, remove=True).consume(basictrees)
     for t in renamed:
         leaves = t.get_leaf_names()
         assert all((x in leaves for x in ("X", "Y", "Z")))
         assert not any((x in leaves for x in ("A", "B", "C", "D", "E", "F")))
-

--- a/tests/scale_tests.py
+++ b/tests/scale_tests.py
@@ -1,7 +1,4 @@
-import fileinput
-
 from phyltr.main import build_pipeline
-from phyltr.plumbing.sources import NewickParser
 from phyltr.commands.height import Height
 from phyltr.commands.length import Length
 from phyltr.commands.scale import Scale
@@ -13,36 +10,28 @@ def test_init_from_args():
     scale = Scale.init_from_args("--scale 4.2")
     assert scale.scalefactor == 4.2
 
-def test_scale():
+def test_scale(basictrees):
     scale_factor = 0.42
-    lines = fileinput.input("tests/treefiles/basic.trees")
-    trees = list(NewickParser().consume(lines))
-    old_heights = [t.get_farthest_leaf()[1] for t in trees]
-    scaled = Scale(scale_factor).consume(trees)
+    old_heights = [t.get_farthest_leaf()[1] for t in basictrees]
+    scaled = Scale(scale_factor).consume(basictrees)
     new_heights = [t.get_farthest_leaf()[1] for t in scaled]
     for old, new in zip(old_heights, new_heights):
         assert new == old * scale_factor
 
-def test_identity():
+def test_identity(basictrees):
     """Make sure scaling with a factor of 1.0 changes nothing."""
-
-    lines = fileinput.input("tests/treefiles/basic.trees")
-    trees = list(NewickParser().consume(lines))
-    unscaled_trees = Scale(1.0).consume(trees)
-    for t1, t2 in zip(trees, unscaled_trees):
+    unscaled_trees = Scale(1.0).consume(basictrees)
+    for t1, t2 in zip(basictrees, unscaled_trees):
         assert t1.write() == t2.write()
 
-def test_roundtrip():
+def test_roundtrip(basictrees):
     """Make sure scaling by x and then 1/x changes nothing."""
-    lines = fileinput.input("tests/treefiles/basic.trees")
-    trees = list(NewickParser().consume(lines))
-
-    heights = Height().consume(trees)
-    scaled_heights = build_pipeline("scale -s 2.0 | scale -s 0.5 | height", trees)
+    heights = Height().consume(basictrees)
+    scaled_heights = build_pipeline("scale -s 2.0 | scale -s 0.5 | height", basictrees)
     for x, y in zip(heights, scaled_heights):
         assert x == y
 
-    lengths = Length().consume(trees)
-    scaled_lengths = build_pipeline("scale -s 2.0 | scale -s 0.5 | length", trees)
+    lengths = Length().consume(basictrees)
+    scaled_lengths = build_pipeline("scale -s 2.0 | scale -s 0.5 | length", basictrees)
     for x, y in zip(lengths, scaled_lengths):
         assert x == y

--- a/tests/sibling_tests.py
+++ b/tests/sibling_tests.py
@@ -1,33 +1,23 @@
-import fileinput
-
 import pytest
 
 from phyltr.main import build_pipeline
-from phyltr.plumbing.sources import NewickParser
 from phyltr.commands.sibling import Sibling
 
 def test_init_from_args():
-    sibling = Sibling.init_from_args("A")
+    Sibling.init_from_args("A")
 
 def test_bad_init_no_args():
     with pytest.raises(ValueError):
         Sibling()
 
-def test_sibling():
-    lines = fileinput.input("tests/treefiles/basic.trees")
-    trees = list(NewickParser().consume(lines))
-    siblings = list(Sibling("A").consume(trees))
+def test_sibling(basictrees):
+    siblings = list(Sibling("A").consume(basictrees))
     assert siblings == ["B","C","B","B","C","B"]
 
-def test_non_leaf_sibling():
-    lines = fileinput.input("tests/treefiles/basic.trees")
-    trees = list(NewickParser().consume(lines))
-    siblings = list(build_pipeline("sibling C", source=trees))
-    print(siblings)
+def test_non_leaf_sibling(basictrees):
+    siblings = list(build_pipeline("sibling C", source=basictrees))
     assert siblings == ["(A,B)","A","(A,B)","(A,B)","A","E"]
 
-def test_bad_params_missing_taxa():
-    lines = fileinput.input("tests/treefiles/basic.trees")
-    trees = list(NewickParser().consume(lines))
+def test_bad_params_missing_taxa(basictrees):
     with pytest.raises(ValueError):
-        siblings = list(Sibling("X").consume(trees))
+        list(Sibling("X").consume(basictrees))

--- a/tests/stat_tests.py
+++ b/tests/stat_tests.py
@@ -1,14 +1,8 @@
-import fileinput
-
-from phyltr.plumbing.sources import NewickParser
 from phyltr.commands.stat import Stat
 
-def test_stat():
-    lines = fileinput.input("tests/treefiles/basic.trees")
-    trees = NewickParser().consume(lines)
+def test_stat(basictrees):
     stat = Stat()
-    for t in stat.consume(trees):
-        pass
+    list(stat.consume(basictrees))
     assert stat.tree_count == 6
     assert stat.taxa_count == 6
     assert stat.topology_count <= stat.tree_count

--- a/tests/subtree_tests.py
+++ b/tests/subtree_tests.py
@@ -1,8 +1,5 @@
-import fileinput
-
 import pytest
 
-from phyltr.plumbing.sources import NewickParser
 from phyltr.main import build_pipeline
 from phyltr.commands.subtree import Subtree
 
@@ -30,40 +27,33 @@ def test_bad_init_no_value_only():
     with pytest.raises(ValueError):
         Subtree(values="bar")
 
-def test_bad_init_empty_file():
+def test_bad_init_empty_file(emptyargs):
     with pytest.raises(ValueError):
-        Subtree(filename="tests/argfiles/empty.txt")
+        Subtree(filename=emptyargs)
 
-def test_subtree():
+def test_subtree(basictrees):
     subtree = Subtree.init_from_args("A,B,C")
-    lines = fileinput.input("tests/treefiles/basic.trees")
-    trees = NewickParser().consume(lines)
-    subtrees = subtree.consume(trees)
+    subtrees = subtree.consume(basictrees)
     expected_taxa = (3, 3, 3, 3, 3, 6)
     for t, n in zip(subtrees, expected_taxa):
         assert len(t.get_leaves()) == n
 
-def test_subtree_2():
+def test_subtree_2(basictrees):
     subtree = Subtree.init_from_args("A,B,F")
-    lines = fileinput.input("tests/treefiles/basic.trees")
-    trees = NewickParser().consume(lines)
-    subtrees = subtree.consume(trees)
+    subtrees = subtree.consume(basictrees)
     expected_taxa = (6, 6, 6, 6, 6, 3)
     for t, n in zip(subtrees, expected_taxa):
         assert len(t.get_leaves()) == n
 
-def test_file_subtree():
-    lines = fileinput.input("tests/treefiles/basic.trees")
-    trees = NewickParser().consume(lines)
-    subtrees = Subtree(filename="tests/argfiles/taxa_abc.txt").consume(trees)
+def test_file_subtree(basictrees):
+    subtrees = Subtree(filename="tests/argfiles/taxa_abc.txt").consume(basictrees)
     expected_taxa = (3, 3, 3, 3, 3, 6)
     for t, n in zip(subtrees, expected_taxa):
         assert len(t.get_leaves()) == n
 
-def test_annotation_subtree():
-    lines = fileinput.input("tests/treefiles/basic.trees")
-    trees = NewickParser().consume(lines)
-    subtrees = build_pipeline("annotate -f tests/argfiles/annotation.csv -k taxon | subtree --attribute f1 --values 0", trees)
+def test_annotation_subtree(basictrees):
+    subtrees = build_pipeline(
+        "annotate -f tests/argfiles/annotation.csv -k taxon | subtree --attribute f1 --values 0", basictrees)
     expected_taxa = (3, 3, 3, 3, 3, 6)
     for t, n in zip(subtrees, expected_taxa):
         assert len(t.get_leaves()) == n

--- a/tests/support_tests.py
+++ b/tests/support_tests.py
@@ -1,6 +1,3 @@
-import fileinput
-
-from phyltr.plumbing.sources import NewickParser
 from phyltr.commands.support import Support
 
 def test_init_from_args():
@@ -20,10 +17,8 @@ def test_init_from_args():
     clades = Support.init_from_args("--sort")
     assert clades.sort == True
 
-def test_clades():
-    lines = fileinput.input("tests/treefiles/basic.trees")
-    trees = NewickParser().consume(lines)
-    supported = Support(filename="/dev/null").consume(trees)
+def test_clades(basictrees):
+    supported = Support(filename="/dev/null").consume(basictrees)
     for t in supported:
         for n in t.traverse():
             assert hasattr(n, "support")

--- a/tests/taxa_tests.py
+++ b/tests/taxa_tests.py
@@ -1,15 +1,8 @@
-import fileinput
-import tempfile
-
-from phyltr.plumbing.sources import NewickParser
 from phyltr.commands.taxa import Taxa
 
 def test_init_from_args():
-    taxa = Taxa.init_from_args("")
+    Taxa.init_from_args("")
 
-def test_taxa():
-    lines = fileinput.input("tests/treefiles/basic.trees")
-    trees = NewickParser().consume(lines)
-    for taxa in Taxa().consume(trees):
+def test_taxa(basictrees):
+    for taxa in Taxa().consume(basictrees):
         assert taxa == ["A", "B", "C", "D", "E", "F"]
-    lines.close()

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -1,14 +1,10 @@
-import fileinput
-
 from phyltr.main import build_pipeline
-from phyltr.plumbing.sources import NewickParser
 
-def test_pipeline():
+def test_pipeline(basictrees):
     """Silly long pipeline to stress test build_pipeline."""
-
-    lines = fileinput.input("tests/treefiles/basic.trees")
-    trees = NewickParser().consume(lines)
-    output = build_pipeline("cat -s 2 | rename -f tests/argfiles/rename.txt | prune X,B | dedupe | uniq | support --sort | stat", source=trees)
+    output = build_pipeline(
+        "cat -s 2 | rename -f tests/argfiles/rename.txt | prune X,B | dedupe | uniq | support --sort | stat",
+        source=basictrees)
     for t in output:
         leaves = t.get_leaf_names()
         assert all((leaves.count(x) == 1  for x in leaves))
@@ -17,8 +13,10 @@ def test_pipeline():
         assert "B" not in leaves
         assert all((x in leaves for x in ("C", "D", "E", "F")))
 
-def test_implicit_source():
-    output = build_pipeline("cat -s 2 | rename -f tests/argfiles/rename.txt | prune X,B | dedupe | uniq | support --sort | stat", source="tests/treefiles/basic.trees")
+def test_implicit_source(treefilepath):
+    output = build_pipeline(
+        "cat -s 2 | rename -f tests/argfiles/rename.txt | prune X,B | dedupe | uniq | support --sort | stat",
+        source=treefilepath("basic.trees"))
     for t in output:
         leaves = t.get_leaf_names()
         assert all((leaves.count(x) == 1  for x in leaves))

--- a/tests/uniq_tests.py
+++ b/tests/uniq_tests.py
@@ -1,6 +1,3 @@
-import fileinput
-
-from phyltr.plumbing.sources import NewickParser
 from phyltr.commands.uniq import Uniq
 from phyltr.commands.length import Length
 
@@ -12,25 +9,20 @@ def test_init_from_args():
         uniq = Uniq.init_from_args("--lengths %s" % lengths)
         assert uniq.lengths == lengths
 
-def test_uniq():
-    lines = fileinput.input("tests/treefiles/basic.trees")
-    trees = list(NewickParser().consume(lines))
-    uniq = Uniq().consume(trees)
+def test_uniq(basictrees):
+    uniq = Uniq().consume(basictrees)
     # The 6 basic trees comprise 5 unique topologies.
     # This is a pretty weak test, but...
     assert sum((1 for t in uniq)) == 5
 
-def test_min_med_max_uniq():
-    lines = fileinput.input("tests/treefiles/basic.trees")
-    trees = list(NewickParser().consume(lines))
-
-    min_uniq = Uniq(lengths="min").consume(trees)
+def test_min_med_max_uniq(basictrees):
+    min_uniq = Uniq(lengths="min").consume(basictrees)
     min_lengths = Length().consume(min_uniq)
 
-    med_uniq = Uniq(lengths="median").consume(trees)
+    med_uniq = Uniq(lengths="median").consume(basictrees)
     med_lengths = Length().consume(med_uniq)
 
-    max_uniq = Uniq(lengths="max").consume(trees)
+    max_uniq = Uniq(lengths="max").consume(basictrees)
     max_lengths = Length().consume(max_uniq)
 
     for l, m, L in zip(min_lengths, med_lengths, max_lengths):


### PR DESCRIPTION
This PR factors out some common setup code in tests to fixtures in `tests/conftest.py` - the [pytest way](https://docs.pytest.org/en/latest/fixture.html) of handling setup code.

Notes:
- I also changed the `treefilenewick` fixture to return not a `generator`, but a `list` of lines. This avoids problems when the `fileinput.input` is not closed in the test code.
- The above change was necessary - I think - because `NewickParser.consume` - unlike `PhyltrCommand.consume` does not close the input stream upon consumption. I'm not sure there is a good reason for this.