### PR TITLE
Fixes import error

### DIFF
--- a/phyltr/__init__.py
+++ b/phyltr/__init__.py
@@ -1,4 +1,4 @@
-from main import run_command, build_pipeline
+from .main import run_command, build_pipeline
 
 from .commands.annotate import Annotate
 from .commands.cat import Cat


### PR DESCRIPTION
A fresh install both from PyPI (`pip install phyltr`) and in developer mode on a local clone (`pip install -e`) is failing because of an import error in `__init__.py` (missing dot for the current directory).